### PR TITLE
allow pointer

### DIFF
--- a/dartsclone/_dartsclone.pyx
+++ b/dartsclone/_dartsclone.pyx
@@ -13,9 +13,8 @@ cdef class DoubleArray:
         cdef char[:] data = <char[:total_size]>self.wrapped.array()
         return bytes(data)
 
-    def set_array(self, bytes array, size_t size=0):
-        cdef const char * data = array
-        self.wrapped.set_array(<const void*> data, size)
+    def set_array(self, const unsigned char[::1] array, size_t size=0):
+        self.wrapped.set_array(<const void*> &array[0], size)
 
     def clear(self):
         self.wrapped.clear()


### PR DESCRIPTION
both works

```python
# natural way
x = bytes(XXX)
set_array(x)
```

```python
# SudachiPy pattern
x = bytes(XXX)
y = memoryview(x)
set_array(y)
```