### PR TITLE
feat: specify cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
         author_email='rixwew@gmail.com',
         url='https://github.com/rixwew/darts-clone-python',
         setup_requires=[
-            'cython',
+            'cython>=0.28',
         ],
         ext_modules=EXTENSIONS,
         zip_safe=False,


### PR DESCRIPTION
To use read-only Buffer Object, cython>=0.28 required.

https://stackoverflow.com/questions/28203670/how-to-use-cython-typed-memoryviews-to-accept-strings-from-python