### PR TITLE
Build wheels and auto-deploy to test.pypi.org by using GitHub actions

### DIFF
--- a/.github/workflows/actions/entrypoint.sh
+++ b/.github/workflows/actions/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+PYTHONS=("cp36-cp36m" "cp37-cp37m" "cp38-cp38")
+
+for PYTHON in ${PYTHONS[@]}; do
+    /opt/python/${PYTHON}/bin/pip install --upgrade pip
+    /opt/python/${PYTHON}/bin/pip install -U wheel auditwheel
+    /opt/python/${PYTHON}/bin/pip wheel . -w /github/workspace/wheelhouse/
+done
+
+for whl in /github/workspace/wheelhouse/*.whl; do
+    auditwheel repair $whl
+done

--- a/.github/workflows/actions/manylinux1_i686/action.yml
+++ b/.github/workflows/actions/manylinux1_i686/action.yml
@@ -1,0 +1,7 @@
+name: 'build wheels with manylinux1_i686'
+description: 'build wheels with manylinux1_i686'
+runs:
+    using: 'docker'
+    image: docker://quay.io/pypa/manylinux1_i686
+    args:
+        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/actions/manylinux1_x86_64/action.yml
+++ b/.github/workflows/actions/manylinux1_x86_64/action.yml
@@ -1,0 +1,7 @@
+name: 'build wheels with manylinux1_x86_64'
+description: 'build wheels with manylinux1_x86_64'
+runs:
+    using: 'docker'
+    image: docker://quay.io/pypa/manylinux1_x86_64
+    args:
+        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,33 @@
+name: build wheels for linux
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: submodule update
+      run: |
+        git submodule update --init --recursive
+    - uses: ./.github/workflows/actions/manylinux1_x86_64/
+    - uses: ./.github/workflows/actions/manylinux1_i686/
+    - name: copy manylinux wheels
+      run: |
+        mkdir dist
+        cp wheelhouse/dartsclone*-manylinux1_x86_64.whl dist/
+        cp wheelhouse/dartsclone*-manylinux1_i686.whl dist/
+    - name: upload wheels
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: dist
+    - name: Publish to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.TEST_PYPI_USER }}
+        PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      run: |
+        pip install twine
+        python -m twine upload -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --repository-url https://test.pypi.org/legacy/ dist/*

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -1,0 +1,41 @@
+name: build wheels for macos
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+        architecture: [x64]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        architecture: ${{ matrix.architecture }}
+        python-version: ${{ matrix.python-version }}
+    - name: build wheel
+      run: |
+        git submodule update --init --recursive
+        pip install -U wheel
+        python setup.py bdist_wheel
+      shell: bash
+    - name: upload wheel
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.python-version }}
+        path: dist
+    - name: Publish to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.TEST_PYPI_USER }}
+        PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      run: |
+        pip install twine
+        python -m twine upload -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --repository-url https://test.pypi.org/legacy/ dist/*
+      shell: bash

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,0 +1,41 @@
+name: build wheels for windows
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [windows-latest]
+        architecture: [x64, x86]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        architecture: ${{ matrix.architecture }}
+        python-version: ${{ matrix.python-version }}
+    - name: build wheel
+      run: |
+        git submodule update --init --recursive
+        pip install -U wheel
+        python setup.py bdist_wheel
+      shell: bash
+    - name: upload wheel
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist_${{ matrix.os }}_${{ matrix.architecture }}_${{ matrix.python-version }}
+        path: dist
+    - name: Publish to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.TEST_PYPI_USER }}
+        PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      run: |
+        pip install twine
+        python -m twine upload -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --repository-url https://test.pypi.org/legacy/ dist/*
+      shell: bash

--- a/.github/workflows/make_sdist.yml
+++ b/.github/workflows/make_sdist.yml
@@ -1,0 +1,31 @@
+name: make source distribution
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: make sdist
+      run: |
+        git submodule update --init --recursive
+        python setup.py sdist
+    - name: upload sdist
+      uses: actions/upload-artifact@v1
+      with:
+        name: dist
+        path: dist
+    - name: Publish to PyPI
+      env:
+        PYPI_USERNAME: ${{ secrets.TEST_PYPI_USER }}
+        PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+      run: |
+        pip install twine
+        python -m twine upload -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} --repository-url https://test.pypi.org/legacy/ dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, Extension
 
 NAME = 'dartsclone'
-VERSION = '0.8.0'
+VERSION = '0.8.5'
 EXTENSIONS = [
     Extension(
         '{0}._{0}'.format(NAME),


### PR DESCRIPTION
The build targets are linux-(amd64|i686), win-(x64|x86), and macos_x64 with python 3.[6-8].
The variations of macos x86 are dropped because the GitHub actions does not support this architecture, and also, Apple no longer supports 32 bit apps.

These build processes are triggered by pushing commits to any branches.
Please set TEST_PYPI_USER  and TEST_PYPI_PASSWORD on the Secret tab of your repository before accepting this PR.

Thanks,