### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.github/workflows/actions/entrypoint.sh
+++ b/.github/workflows/actions/entrypoint.sh
@@ -8,6 +8,6 @@ for PYTHON in ${PYTHONS[@]}; do
     /opt/python/${PYTHON}/bin/pip wheel . -w /github/workspace/wheelhouse/
 done
 
-for whl in /github/workspace/wheelhouse/*.whl; do
-    auditwheel repair $whl
+for whl in /github/workspace/wheelhouse/*linux_"$(uname -m)".whl; do
+    auditwheel repair $whl --plat manylinux2014_"$(uname -m)"
 done

--- a/.github/workflows/actions/manylinux1_i686/action.yml
+++ b/.github/workflows/actions/manylinux1_i686/action.yml
@@ -1,7 +1,0 @@
-name: 'build wheels with manylinux1_i686'
-description: 'build wheels with manylinux1_i686'
-runs:
-    using: 'docker'
-    image: docker://quay.io/pypa/manylinux1_i686
-    args:
-        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/actions/manylinux1_x86_64/action.yml
+++ b/.github/workflows/actions/manylinux1_x86_64/action.yml
@@ -1,7 +1,0 @@
-name: 'build wheels with manylinux1_x86_64'
-description: 'build wheels with manylinux1_x86_64'
-runs:
-    using: 'docker'
-    image: docker://quay.io/pypa/manylinux1_x86_64
-    args:
-        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/actions/manylinux2014_aarch64/action.yml
+++ b/.github/workflows/actions/manylinux2014_aarch64/action.yml
@@ -1,0 +1,7 @@
+name: 'build wheels with manylinux2014_aarch64'
+description: 'build wheels with manylinux2014_aarch64'
+runs:
+    using: 'docker'
+    image: docker://quay.io/pypa/manylinux2014_aarch64
+    args:
+        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/actions/manylinux2014_i686/action.yml
+++ b/.github/workflows/actions/manylinux2014_i686/action.yml
@@ -1,0 +1,7 @@
+name: 'build wheels with manylinux2014_i686'
+description: 'build wheels with manylinux2014_i686'
+runs:
+    using: 'docker'
+    image: docker://quay.io/pypa/manylinux2014_i686
+    args:
+        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/actions/manylinux2014_x86_64/action.yml
+++ b/.github/workflows/actions/manylinux2014_x86_64/action.yml
@@ -1,0 +1,7 @@
+name: 'build wheels with manylinux2014_x86_64'
+description: 'build wheels with manylinux2014_x86_64'
+runs:
+    using: 'docker'
+    image: docker://quay.io/pypa/manylinux2014_x86_64
+    args:
+        - .github/workflows/actions/entrypoint.sh

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,16 +12,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
     - name: submodule update
       run: |
         git submodule update --init --recursive
-    - uses: ./.github/workflows/actions/manylinux1_x86_64/
-    - uses: ./.github/workflows/actions/manylinux1_i686/
+    - uses: ./.github/workflows/actions/manylinux2014_x86_64/
+    - uses: ./.github/workflows/actions/manylinux2014_i686/
+    - uses: ./.github/workflows/actions/manylinux2014_aarch64/
     - name: copy manylinux wheels
       run: |
         mkdir dist
-        cp wheelhouse/dartsclone*-manylinux1_x86_64.whl dist/
-        cp wheelhouse/dartsclone*-manylinux1_i686.whl dist/
+        cp wheelhouse/dartsclone*manylinux2014_x86_64.whl dist/
+        cp wheelhouse/dartsclone*manylinux2014_i686.whl dist/
+        cp wheelhouse/dartsclone*manylinux2014_aarch64.whl dist/
     - name: upload wheels
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
Added linux aarch64 wheel build support.
Related to https://github.com/rixwew/darts-clone-python/issues/10, @rixwew Could you please review this PR?