### PR TITLE
Fix github action errors on windows and macos environments

### DIFF
--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-10.15]
         architecture: [x64]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2019]
         architecture: [x64, x86]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description

* Changed windows and mac environment label
* Added build steps for python 3.9 and 3.10
* related to #12 