### PR TITLE
Removed python 3.10 build step for mac/win

### DIFF
--- a/.github/workflows/actions/entrypoint.sh
+++ b/.github/workflows/actions/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PYTHONS=("cp36-cp36m" "cp37-cp37m" "cp38-cp38")
+PYTHONS=("cp36-cp36m" "cp37-cp37m" "cp38-cp38", "cp39-cp39")
 
 for PYTHON in ${PYTHONS[@]}; do
     /opt/python/${PYTHON}/bin/pip install --upgrade pip

--- a/.github/workflows/build_mac.yml
+++ b/.github/workflows/build_mac.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [macos-10.15]
         architecture: [x64]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-2019]
         architecture: [x64, x86]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
# Description
* removed python 3.10 build step for mac/win
* added python3.9 build step for linux
* related to #12