### PR TITLE
support buffer protocol

### DIFF
--- a/dartsclone/_dartsclone.pxd
+++ b/dartsclone/_dartsclone.pxd
@@ -51,3 +51,6 @@ cdef extern from "darts.h":
 
 cdef class DoubleArray:
     cdef CppDoubleArray *wrapped
+    cdef Py_buffer _buf
+    cdef Py_ssize_t _shape[1]
+    cdef Py_ssize_t _strides[1]

--- a/test/test_darts.py
+++ b/test/test_darts.py
@@ -12,7 +12,7 @@ class DoubleArrayTest(unittest.TestCase):
     def test_darts_no_values(self):
         keys = ['test', 'テスト', 'テストケース']
         darts = DoubleArray()
-        darts.build(sorted([key.encode() for key in keys]))
+        darts.build([key.encode() for key in keys])
         self.assertEqual(1, darts.exact_match_search('テスト'.encode(), pair_type=False))
         self.assertEqual(0, darts.common_prefix_search('testcase'.encode(), pair_type=False)[0])
         self.assertEqual(0, darts.exact_match_search('test'.encode(), pair_type=False))
@@ -21,7 +21,7 @@ class DoubleArrayTest(unittest.TestCase):
     def test_darts_with_values(self):
         keys = ['test', 'テスト', 'テストケース']
         darts = DoubleArray()
-        darts.build(sorted([key.encode() for key in keys]), values=[3, 5, 1])
+        darts.build([key.encode() for key in keys], values=[3, 5, 1])
         self.assertEqual(5, darts.exact_match_search('テスト'.encode(), pair_type=False))
         self.assertEqual(3, darts.common_prefix_search('testcase'.encode(), pair_type=False)[0])
         self.assertEqual(1, darts.exact_match_search('テストケース'.encode(), pair_type=False))
@@ -30,7 +30,7 @@ class DoubleArrayTest(unittest.TestCase):
     def test_darts_save(self):
         keys = ['test', 'テスト', 'テストケース']
         darts = DoubleArray()
-        darts.build(sorted([key.encode() for key in keys]), values=[3, 5, 1])
+        darts.build([key.encode() for key in keys], values=[3, 5, 1])
         with tempfile.NamedTemporaryFile('wb') as output_file:
             darts.save(output_file.name)
             output_file.flush()
@@ -54,12 +54,19 @@ class DoubleArrayTest(unittest.TestCase):
     def test_darts_array(self):
         keys = ['test', 'テスト', 'テストケース']
         darts = DoubleArray()
-        darts.build(sorted([key.encode() for key in keys]), values=[3, 5, 1])
+        darts.build([key.encode() for key in keys], values=[3, 5, 1])
         array = darts.array()
         darts = DoubleArray()
         darts.set_array(array)
         self.assertEqual(5, darts.exact_match_search('テスト'.encode(), pair_type=False))
         self.assertEqual(3, darts.common_prefix_search('testcase'.encode(), pair_type=False)[0])
+
+    def test_darts_buffers(self):
+        keys = ['test', 'テスト', 'テストケース']
+        darts = DoubleArray()
+        darts.build([memoryview(key.encode()) for key in keys], values=[3, 5, 1])
+        self.assertEqual(5, darts.exact_match_search(memoryview('テスト'.encode()), pair_type=False))
+        self.assertEqual(3, darts.common_prefix_search(memoryview('testcase'.encode()), pair_type=False)[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

* This patch allows use of any object that supports buffer protocol where only bytes can be accepted now.
* Thus this enables one to use memory mapped buffer for read-only operations.
